### PR TITLE
add position reporting for mobs and update bptimer-api-client to fix bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "bpsr-meter",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bpsr-meter",
-            "version": "0.4.5",
+            "version": "0.4.6",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@bufbuild/protobuf": "^2.10.0",
                 "@electron-toolkit/preload": "^3.0.2",
                 "@electron-toolkit/utils": "^4.0.0",
                 "@tailwindcss/vite": "^4.1.15",
-                "@woheedev/bptimer-api-client": "^0.0.8",
+                "@woheedev/bptimer-api-client": "^0.1.3",
                 "adm-zip": "^0.5.16",
                 "bindings": "^1.5.0",
                 "cap": "^0.2.1",
@@ -95,6 +95,7 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -1198,7 +1199,6 @@
             "dev": true,
             "license": "BSD-2-Clause",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "cross-dirname": "^0.1.0",
                 "debug": "^4.3.4",
@@ -1220,7 +1220,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -1237,7 +1236,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -1252,7 +1250,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -2977,6 +2974,7 @@
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -3050,6 +3048,7 @@
             "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -3159,9 +3158,9 @@
             }
         },
         "node_modules/@woheedev/bptimer-api-client": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.0.8.tgz",
-            "integrity": "sha512-m09JhU/kuH4Oop6pufZO9EtXslqLFJBXYSqjg5HKcPk5RoOEvXLwYiVxeMrbFw+yMQwPFieDjZ0GxQSq1iWMtQ==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.1.3.tgz",
+            "integrity": "sha512-2J7eSqrqfGKLot3mhK0hVv5bsA5Px6zRgtsI040V1inXzlm04Vt9lS54werkZ6z8vCdoIWTY9HL3XZm1yuQv9g==",
             "license": "AGPL-3.0-or-later"
         },
         "node_modules/@xmldom/xmldom": {
@@ -3269,6 +3268,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3338,6 +3338,7 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -3879,6 +3880,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.19",
                 "caniuse-lite": "^1.0.30001751",
@@ -4730,8 +4732,7 @@
             "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -4950,6 +4951,7 @@
             "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.0.12",
                 "builder-util": "26.0.11",
@@ -5138,6 +5140,7 @@
             "integrity": "sha512-VuFEI1yQ7BH3RYI5VZtwFlzGp4rpPRd5oEc26ZQIItVLcLTbXt4/O7o4hs+1fyg9Q3NvGAifgX5Vp5EBOIFpAg==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@electron/get": "^2.0.0",
                 "@types/node": "^22.7.7",
@@ -5433,7 +5436,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@electron/asar": "^3.2.1",
                 "debug": "^4.1.1",
@@ -5454,7 +5456,6 @@
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -5478,17 +5479,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/encoding": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "iconv-lite": "^0.6.2"
             }
         },
         "node_modules/end-of-stream": {
@@ -7707,6 +7697,7 @@
             "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -8603,7 +8594,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "commander": "^9.4.0"
             },
@@ -8621,7 +8611,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -8783,6 +8772,7 @@
             "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -9048,6 +9038,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10280,7 +10271,6 @@
             "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mkdirp": "^0.5.1",
                 "rimraf": "~2.6.2"
@@ -10344,7 +10334,6 @@
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -10359,7 +10348,6 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -10589,6 +10577,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10819,6 +10808,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
             "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@tailwindcss/vite": "^4.1.15",
-        "@woheedev/bptimer-api-client": "^0.0.8",
+        "@woheedev/bptimer-api-client": "^0.1.3",
         "adm-zip": "^0.5.16",
         "bindings": "^1.5.0",
         "cap": "^0.2.1",

--- a/proto/packet.ts
+++ b/proto/packet.ts
@@ -677,6 +677,7 @@ class PacketProcessor {
 
             const monsterId = this.userDataManager.enemyCache.monsterId.get(enemyUuid);
             const maxHp = this.userDataManager.enemyCache.maxHp.get(enemyUuid);
+            const position = this.userDataManager.enemyCache.position.get(enemyUuid);
 
             if (!monsterId || !maxHp || maxHp === 0) {
                 return;
@@ -691,11 +692,20 @@ class PacketProcessor {
             }
 
             const hpPercentage = (currentHp / maxHp) * 100;
-
+            const pos_x = position?.x;
+            const pos_y = position?.y;
+            const pos_z = position?.z;
             const line = this.userDataManager.getCurrentLineId();
 
             this.bpTimerClient
-                .reportHP(monsterId, hpPercentage, line)
+                .reportHP({
+                    monster_id: monsterId,
+                    hp_pct: hpPercentage,
+                    line: line,
+                    pos_x: pos_x,
+                    pos_y: pos_y,
+                    pos_z: pos_z,
+                })
                 .catch((err) => {
                     this.logger.debug(
                         `[BPTimer] Failed to report HP threshold: ${err.message}`,
@@ -727,6 +737,7 @@ class PacketProcessor {
             if (attrCollection && attrCollection.Attrs) {
                 switch (entity.entType) {
                     case EEntityType.EntMonster:
+                        this.#processPositionAttrs(entityUuidStr, 'monster', attrCollection.Attrs);
                         this.#processEnemyAttrs(entityUuidStr, entityUid, attrCollection.Attrs);
                         break;
                     case EEntityType.EntChar:


### PR DESCRIPTION
feat: add position reporting for mobs
(calls processPositionAttrs in processSyncNearEntities to cache to avoid empty position on first sight)

chore: update bptimer-api-client 
(fixes a rate limit bug when backend does not return a 200)