### PR TITLE
feat: update bptimer-api-client to v0.2.0 (multi-region support)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@electron-toolkit/preload": "^3.0.2",
                 "@electron-toolkit/utils": "^4.0.0",
                 "@tailwindcss/vite": "^4.1.15",
-                "@woheedev/bptimer-api-client": "^0.1.4",
+                "@woheedev/bptimer-api-client": "^0.2.0",
                 "adm-zip": "^0.5.16",
                 "bindings": "^1.5.0",
                 "cap": "^0.2.1",
@@ -3155,9 +3155,9 @@
             }
         },
         "node_modules/@woheedev/bptimer-api-client": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.1.4.tgz",
-            "integrity": "sha512-m/d6UyG8EigJFAitoe+AJRiCNaZ7DRWK7xvIhHJh1XMGfdqT85wn+CZWvjOzCguc5zXEz+AoqKFaMMp51rP1Lw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.2.0.tgz",
+            "integrity": "sha512-IraoDAyZFYoJ3NWIPMBnQaxnKlXrJuUCA1FYEQupvQik8bXgOHnQgKGLl1kj0wRel3R4sSDrf0jj2e6VZby+JA==",
             "license": "AGPL-3.0-or-later"
         },
         "node_modules/@xmldom/xmldom": {
@@ -3808,23 +3808,43 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+            "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
                 "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/iconv-lite": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/boolean": {
@@ -4600,9 +4620,9 @@
             }
         },
         "node_modules/config-file-ts/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6784,6 +6804,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@tailwindcss/vite": "^4.1.15",
-        "@woheedev/bptimer-api-client": "^0.1.4",
+        "@woheedev/bptimer-api-client": "^0.2.0",
         "adm-zip": "^0.5.16",
         "bindings": "^1.5.0",
         "cap": "^0.2.1",

--- a/proto/packet.ts
+++ b/proto/packet.ts
@@ -383,6 +383,10 @@ class PacketProcessor {
                 this.userDataManager.setName(playerUid, charBase.name);
             }
 
+            if (charBase.accountId) {
+                this.userDataManager.setLocalPlayerAccountId(charBase.accountId);
+            }
+
             if (charBase.fightPoint) this.userDataManager.setFightPoint(playerUid, charBase.fightPoint);
 
             if (!vData.professionList) return;
@@ -644,6 +648,8 @@ class PacketProcessor {
             const pos_y = position?.y;
             const pos_z = position?.z;
             const line = this.userDataManager.getCurrentLineId();
+            const account_id = this.userDataManager.localPlayerAccountId ?? undefined;
+            const uid = this.userDataManager.localPlayerUid ?? undefined;
 
             this.bpTimerClient
                 .reportHP({
@@ -653,6 +659,8 @@ class PacketProcessor {
                     pos_x: pos_x,
                     pos_y: pos_y,
                     pos_z: pos_z,
+                    account_id: account_id,
+                    uid: uid,
                 })
                 .catch((err) => {
                     this.logger.debug(

--- a/src/server/dataManager.ts
+++ b/src/server/dataManager.ts
@@ -549,6 +549,7 @@ export class UserDataManager {
     logDirExist: Set<string>;
     enemyCache: EnemyCache;
     localPlayerUid: number | null;
+    localPlayerAccountId: string | null;
     localPlayerPosition: PlayerPosition | null;
     lastLogTime?: number;
     sceneData: Map<string, SceneInfo>;
@@ -583,12 +584,19 @@ export class UserDataManager {
         };
         this.sceneData = new Map();
         this.localPlayerUid = null;
+        this.localPlayerAccountId = null;
         this.localPlayerPosition = null;
     }
 
     setLocalPlayerUid(uid: number): void {
         if (this.localPlayerUid !== uid) {
             this.localPlayerUid = uid;
+        }
+    }
+
+    setLocalPlayerAccountId(accountId: string): void {
+        if (this.localPlayerAccountId !== accountId) {
+            this.localPlayerAccountId = accountId;
         }
     }
 


### PR DESCRIPTION
Added account_id and uid to submission fields to be used for:
- multi-region support (able to detect region from account_id)
- future implementations (plan on using uid to link to a users account on bptimer)

Full bptimer-api-client changes can be seen here: https://github.com/woheedev/bptimer/commit/b92a61211ad1518e83038d7ab72355ac092eb515