### PR TITLE
chore: update bptimer-api-client to v0.2.2 and bump version to 0.4.93

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "bpsr-meter",
-    "version": "0.4.92",
+    "version": "0.4.93",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bpsr-meter",
-            "version": "0.4.92",
+            "version": "0.4.93",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@bufbuild/protobuf": "^2.10.0",
                 "@electron-toolkit/preload": "^3.0.2",
                 "@electron-toolkit/utils": "^4.0.0",
                 "@tailwindcss/vite": "^4.1.15",
-                "@woheedev/bptimer-api-client": "^0.2.0",
+                "@woheedev/bptimer-api-client": "^0.2.2",
                 "adm-zip": "^0.5.16",
                 "bindings": "^1.5.0",
                 "cap": "^0.2.1",
@@ -3155,9 +3155,9 @@
             }
         },
         "node_modules/@woheedev/bptimer-api-client": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.2.0.tgz",
-            "integrity": "sha512-IraoDAyZFYoJ3NWIPMBnQaxnKlXrJuUCA1FYEQupvQik8bXgOHnQgKGLl1kj0wRel3R4sSDrf0jj2e6VZby+JA==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@woheedev/bptimer-api-client/-/bptimer-api-client-0.2.2.tgz",
+            "integrity": "sha512-Pid6yp5N0gzz6GjC+lfnmovR7j31cnaW57uu+UzgxuXdPjEL7g/yfZ/HU7qHZQiKoFGrJy8dBUVZ4lrQzaQBcg==",
             "license": "AGPL-3.0-or-later"
         },
         "node_modules/@xmldom/xmldom": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bpsr-meter",
-    "version": "0.4.92",
+    "version": "0.4.93",
     "description": "BPSR Meter",
     "author": "Denoder",
     "type": "module",
@@ -26,7 +26,7 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@tailwindcss/vite": "^4.1.15",
-        "@woheedev/bptimer-api-client": "^0.2.0",
+        "@woheedev/bptimer-api-client": "^0.2.2",
         "adm-zip": "^0.5.16",
         "bindings": "^1.5.0",
         "cap": "^0.2.1",


### PR DESCRIPTION
# Changes
- Added mob record prefetch to replace hardcoded values

This change will ensure that there is no need to push a new api client update when a new mob is added/removed.

**Note:** This is a low priority update and currently only used to capture HP reports for the new `Snow Nappo` event mob.